### PR TITLE
Add `areaBrightness` to `LineSeriesType`, apply within `AnimatedArea`

### DIFF
--- a/packages/x-charts/src/LineChart/AnimatedArea.tsx
+++ b/packages/x-charts/src/LineChart/AnimatedArea.tsx
@@ -16,7 +16,9 @@ export const AreaElementPath = styled(animated.path, {
   stroke: 'none',
   fill: ownerState.isHighlighted
     ? d3Color(ownerState.color)!.brighter(1).formatHex()
-    : d3Color(ownerState.color)!.brighter(0.5).formatHex(),
+    : d3Color(ownerState.color)!
+        .brighter(ownerState.brightness ?? 0.5)
+        .formatHex(),
   transition: 'opacity 0.2s ease-in, fill 0.2s ease-in',
   opacity: ownerState.isFaded ? 0.3 : 1,
 }));
@@ -74,6 +76,7 @@ AnimatedArea.propTypes = {
   // ----------------------------------------------------------------------
   d: PropTypes.string.isRequired,
   ownerState: PropTypes.shape({
+    brightness: PropTypes.number,
     classes: PropTypes.object,
     color: PropTypes.string.isRequired,
     id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,

--- a/packages/x-charts/src/LineChart/AreaElement.tsx
+++ b/packages/x-charts/src/LineChart/AreaElement.tsx
@@ -28,6 +28,7 @@ export type AreaElementClassKey = keyof AreaElementClasses;
 export interface AreaElementOwnerState {
   id: SeriesId;
   color: string;
+  brightness?: number;
   isFaded: boolean;
   isHighlighted: boolean;
   classes?: Partial<AreaElementClasses>;
@@ -95,6 +96,7 @@ export interface AreaElementProps
 function AreaElement(props: AreaElementProps) {
   const {
     id,
+    brightness,
     classes: innerClasses,
     color,
     highlightScope,
@@ -115,6 +117,7 @@ function AreaElement(props: AreaElementProps) {
   const ownerState = {
     id,
     classes: innerClasses,
+    brightness,
     color,
     isFaded,
     isHighlighted,

--- a/packages/x-charts/src/LineChart/AreaElement.tsx
+++ b/packages/x-charts/src/LineChart/AreaElement.tsx
@@ -148,6 +148,7 @@ AreaElement.propTypes = {
   // ----------------------------------------------------------------------
   classes: PropTypes.object,
   color: PropTypes.string.isRequired,
+  brightness: PropTypes.number,
   d: PropTypes.string.isRequired,
   highlightScope: PropTypes.shape({
     faded: PropTypes.oneOf(['global', 'none', 'series']),

--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -120,13 +120,14 @@ function AreaPlot(props: AreaPlotProps) {
       {completedData
         .reverse()
         .map(
-          ({ d, seriesId, color, highlightScope, area }) =>
+          ({ d, seriesId, color, areaBrightness, highlightScope, area }) =>
             !!area && (
               <AreaElement
                 key={seriesId}
                 id={seriesId}
                 d={d}
                 color={color}
+                brightness={areaBrightness}
                 highlightScope={highlightScope}
                 slots={slots}
                 slotProps={slotProps}

--- a/packages/x-charts/src/models/seriesType/line.ts
+++ b/packages/x-charts/src/models/seriesType/line.ts
@@ -56,6 +56,7 @@ export interface LineSeriesType
   dataKey?: string;
   stack?: string;
   area?: boolean;
+  areaBrightness?: number;
   label?: string;
   curve?: CurveType;
   /**


### PR DESCRIPTION
Demonstrates support for parameterizing area brightness, rather than hardcoding it at 0.5.

- Adds numeric `areaBrightness` field to `LineSeriesType`
- Adds `brightness` prop to `AreaElement`, which is added to its `ownerState`
- Parameter is utilized within `AreaElementPath`, defaulting to the pre-existing value of 0.5

Tests and documentation updates to follow if agreed to by MUI X maintainers